### PR TITLE
Add headers injection capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,8 +118,10 @@ dist
 .vscode
 .github
 config.yml
+config*.yaml
 forwardedemails.txt
 config*.yml
+config*.yaml
 
 *.pyc
 *.old

--- a/config/injections.yml
+++ b/config/injections.yml
@@ -8,5 +8,8 @@ links:
   #shl.com: https://www.bing.com/search?q=an+elephant 
   #office.com: https://www.bing.com/search?q=a+squirrel
   #google.com: https://www.bing.com/search?q=a+zebra 
+headers:
+  X-Added-Header: "Test added header"
+  X-Phish-Test: "Authorized Phishing Test"
 tracking_url: "https://yourtrackingpixeldomain.com/"
 unc_path: "\\\\<YOUR IP>\\images\\xxxxx.png"

--- a/mail-in-the-middle.py
+++ b/mail-in-the-middle.py
@@ -48,6 +48,10 @@ def main():
     # Init logging
     log_filename = "logs/" + datetime.now().strftime('%Y%m%d_%H%M%S') + '_mailinthemiddle.log'
     init_logging(log_filename)
+    # Create forwarded emails list file if it does not exists
+    if not os.path.exists("forwardedemails.txt"):
+        open("forwardedemails.txt", "w").close()
+
     # Create Maitm object
     maitm = Maitm(config_file=arguments.config, 
                   only_new=arguments.new,


### PR DESCRIPTION
Add header injection capabilities.
You can add a new section in the file injections.yml like this to inject two new headers in the resulting email:

```
headers:
  X-Added-Header: "Test added header"
  X-Phish-Test: "Authorized Phishing Test"
```

This can be specially useful to abuse headers used by legitimate allowed third-party Phishing solutions. If the target has specific rules to bypass phishing scans when a header is found, maybe you hit the jackpot by mimicking that legitimate phishing email header.